### PR TITLE
Include repo name + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Chrome extension that allows you to share GitHub Pull Requests to Slack with a
 - Share GitHub PRs to Slack with a single click via an inline button
 - Customizable Slack webhook URL
 - Seamless integration into GitHub's PR interface
-- Includes PR title and URL in the Slack message
+- Includes repository name, PR title and URL in the Slack message
 - Settings are saved in Chrome sync storage
 
 ![Screenshot](./screenshot.png)

--- a/src/content.ts
+++ b/src/content.ts
@@ -131,7 +131,12 @@ class PRExtractor {
     const parts = pathname.split('/');
     
     if (parts.length >= 3) {
-      // parts[1] is owner, parts[2] is repo name
+    // parts[1] is owner, parts[2] is repo name
+    if (
+      parts.length >= 3 &&
+      parts[1] && parts[2] &&
+      parts[1].trim() !== '' && parts[2].trim() !== ''
+    ) {
       return parts[2];
     }
     

--- a/src/content.ts
+++ b/src/content.ts
@@ -25,7 +25,8 @@ class PRExtractor {
   }
 
   private isPRPage(): boolean {
-    return window.location.pathname.includes('/pull/');
+    // Match /owner/repo/pull/number exactly (no trailing slash or extra path)
+    return /^\/[^\/]+\/[^\/]+\/pull\/\d+$/.test(window.location.pathname);
   }
 
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -130,7 +130,6 @@ class PRExtractor {
     const pathname = window.location.pathname;
     const parts = pathname.split('/');
     
-    if (parts.length >= 3) {
     // parts[1] is owner, parts[2] is repo name
     if (
       parts.length >= 3 &&

--- a/src/content.ts
+++ b/src/content.ts
@@ -14,12 +14,27 @@ class PRExtractor {
       if (currentUrl !== lastUrl) {
         lastUrl = currentUrl;
         this.injectShareButton();
+      } else {
+        // Check if our button still exists, if not, re-inject it
+        const existingButton = document.querySelector('[data-slack-share-button]');
+        if (!existingButton && this.isPRPage()) {
+          this.injectShareButton();
+        }
       }
     }).observe(document.body, { subtree: true, childList: true })
   }
 
+  private isPRPage(): boolean {
+    return window.location.pathname.includes('/pull/');
+  }
+
 
   private injectShareButton() {
+    // Only inject on PR pages
+    if (!this.isPRPage()) {
+      return;
+    }
+
     // Remove any existing share buttons first
     const existingButton = document.querySelector('[data-slack-share-button]');
     if (existingButton) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -123,18 +123,36 @@ class PRExtractor {
     };
   }
 
+  private getRepositoryName(): string {
+    // Extract repository name from GitHub URL
+    // URL format: https://github.com/owner/repo/pull/123
+    const pathname = window.location.pathname;
+    const parts = pathname.split('/');
+    
+    if (parts.length >= 3) {
+      // parts[1] is owner, parts[2] is repo name
+      return parts[2];
+    }
+    
+    return '';
+  }
+
   private formatSlackMessage(prInfo: PRInfo, settings: Settings) {
+    const repoName = this.getRepositoryName();
+    const prefix = repoName ? `${repoName} - ` : '';
+    
     if (settings.regex) {
       const regex = new RegExp(settings.regex);
       prInfo.title = prInfo.title.replace(regex, "")
     }
+    
     if (settings.username) {
       return {
-        text: `PR from <@${settings.username}>: <${prInfo.url}|${prInfo.title}>`,
+        text: `PR from <@${settings.username}>: <${prInfo.url}|${prefix}${prInfo.title}>`,
       }
     }
     return {
-      text: `PR: <${prInfo.url}|${prInfo.title}>`,
+      text: `PR: <${prInfo.url}|${prefix}${prInfo.title}>`,
       unfurl_links: false
     };
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub PR to Slack Sharing",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Share GitHub Pull Requests to Slack with a predefined template",
   "permissions": [
     "activeTab",

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,5 +1,4 @@
 import './popup.css'
-import { loadSettings } from './settings';
 import { Settings } from './types';
 
 class PopupManager {
@@ -21,10 +20,19 @@ class PopupManager {
   }
 
   private async loadSettings() {
-    const settings = await loadSettings();
-    this.webhookInput.value = settings.webhookUrl;
-    this.usernameInput.value = settings.username;
-    this.regexInput.value = settings.regex;
+    try {
+      // Load settings directly from storage for the popup, not using the runtime loadSettings
+      // which throws an error if webhook URL is not set
+      const settings = await chrome.storage.sync.get(['webhookUrl', 'username', 'regex']);
+      this.webhookInput.value = settings.webhookUrl || '';
+      this.usernameInput.value = settings.username || '';
+      this.regexInput.value = settings.regex || '^[a-zA-Z]{3}-[0-9]+';
+    } catch (error) {
+      // Set default values if loading fails
+      this.webhookInput.value = '';
+      this.usernameInput.value = '';
+      this.regexInput.value = '^[a-zA-Z]{3}-[0-9]+';
+    }
   }
 
   private setupEventListeners() {


### PR DESCRIPTION
This pull request updates the Chrome extension to improve the Slack sharing functionality and robustness of the GitHub PR integration. The most notable changes are the addition of repository names to shared Slack messages, improved button injection logic, and enhancements to settings handling in the popup.

**Slack message improvements:**
* Slack messages now include the repository name along with the PR title and URL, providing more context when sharing PRs. (`src/content.ts`, `README.md`) [[1]](diffhunk://#diff-b769f60434f9ce6a59837e3786f8b1ef4d13930a04c73e4d525ffa17ad9f665cR126-R155) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10)

**UI robustness:**
* The logic for injecting the Slack share button has been improved to ensure the button is only present on PR pages and is re-injected if removed. (`src/content.ts`)

**Settings handling:**
* The popup now loads settings directly from Chrome storage, providing default values and gracefully handling missing or unset settings. (`src/popup.ts`)

**General maintenance:**
* The extension version has been bumped from `1.0.2` to `1.1.0` to reflect these new features. (`src/manifest.json`)
* Minor cleanup in imports for the popup code. (`src/popup.ts`)